### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy>=1.11.1
 pandas>=0.20.1
 pyro-ppl==0.3.0
 pymc3==3.9.0
-pyprob==1.2.0
+pyprob>=1.2.0


### PR DESCRIPTION
Hi UBC,

This is the JPL team requesting if you can change your pyprob requirement to >=1.2.0. We are in the midst of updating the torch version on the Docker images to torch 1.7.0, but pyprob 1.2.0 only works for torch less <= 1.5.0. https://gitlab.com/datadrivendiscovery/images/-/jobs/1225625411

